### PR TITLE
Added an attribute parameter to enable time skipping

### DIFF
--- a/src/be/tarsos/transcoder/Attributes.java
+++ b/src/be/tarsos/transcoder/Attributes.java
@@ -60,6 +60,12 @@ public class Attributes {
 	 */
 	private Integer volume = null;
 
+	/**
+	 * The seek time value for the attributes process. If null or not specified a
+	 * the default value will be 0. If 0 no seek will be performed.
+	 */
+	private Integer seekTime = null;
+
 	public Attributes(final String format, final String codec, final Integer samplingRate,
 			final Integer channels, final Integer bitRate, final Integer volume) {
 		setBitRate(bitRate);
@@ -188,6 +194,27 @@ public class Attributes {
 	}
 
 	/**
+	 * Returns the seek time value for the attributes process.
+	 * 
+	 * @return The seek time value for the attributes process.
+	 */
+	public Integer getSeekTime() {
+		return seekTime;
+	}
+
+	/**
+	 * Sets the seek time value for the attributes process. If null or
+         * not specified the default value will be 0. If 0 no seek will be
+	 * performed.
+	 * 
+	 * @param seekTime
+	 *            The seek time value for the attributes process.
+	 */
+	public void setSeekTime(Integer seekTime) {
+		this.seekTime = seekTime;
+	}
+
+	/**
 	 * The format name for the encoded target multimedia file. Be sure this
 	 * format is supported by checking your ffmpeg version.
 	 */
@@ -237,8 +264,8 @@ public class Attributes {
 	@Override
 	public String toString() {
 		return String.format(
-				"%s format=%s, codec=%s, bitrate=%s, samplingrate=%s,duration=%s, channels=%s , volume=%s",
-				getClass().getName(), format, codec, bitRate, samplingRate, duration, channels, volume);
+				"%s format=%s, codec=%s, bitrate=%s, samplingrate=%s, duration=%s, channels=%s , volume=%s seekTime=%s",
+				getClass().getName(), format, codec, bitRate, samplingRate, duration, channels, volume, seekTime);
 	}
 
 }

--- a/src/be/tarsos/transcoder/ffmpeg/Encoder.java
+++ b/src/be/tarsos/transcoder/ffmpeg/Encoder.java
@@ -297,6 +297,18 @@ public class Encoder {
 	private FFMPEGExecutor construcExecutor(Attributes attributes,String source){
 		FFMPEGExecutor ffmpeg = locator.createExecutor();
 		
+		Integer seekTime = attributes.getSeekTime();
+		if (seekTime != null) {
+			ffmpeg.addArgument("-ss");
+			int S = seekTime; //ms
+			int s = S/1000;   //sec
+			int m = s/60;     //min
+			int h = m/60;     //hr
+			ffmpeg.addArgument(String
+				.format("%2d:%2d:%2d.%3d", h%100, m%60, s%60, S%1000)
+				.replaceAll(" ","0"));
+		}
+		
 		ffmpeg.addArgument("-i");
 		ffmpeg.addArgument(source);
 


### PR DESCRIPTION
Added a seek parameter (in milliseconds) so that ffmeg can attempt to quickly seek to a specific time in an audio stream. I found this useful for working near the end of really long files. It's much faster than decoding and discarding frames to reach the desired point in the stream.