### PR TITLE
Transcoder.java - remove print stack trace

### DIFF
--- a/src/be/tarsos/transcoder/Transcoder.java
+++ b/src/be/tarsos/transcoder/Transcoder.java
@@ -206,7 +206,6 @@ public class Transcoder {
 			info = e.getInfo(new File(file));
 		} catch (final InputFormatException e1) {
 			LOG.severe("Unknown input file format: " + file);
-			e1.printStackTrace();
 		} catch (final EncoderException e1) {
 			LOG.warning("Could not get information about:" + file);
 		}


### PR DESCRIPTION
Hello
I believe that printing the stack trace is acceptable when developing and debugging, but afterwards it should never be visible to end users, ensuring a better user experience and safety.