### PR TITLE
parseAudioAttributes: Fix duration parse and calculation

### DIFF
--- a/src/be/tarsos/transcoder/ffmpeg/Encoder.java
+++ b/src/be/tarsos/transcoder/ffmpeg/Encoder.java
@@ -139,7 +139,7 @@ public class Encoder {
 			EncoderException {
 		Pattern p1 = Pattern.compile(".*\\s*Input #0, (\\w+).+$\\s*.*", Pattern.CASE_INSENSITIVE
 				| Pattern.MULTILINE | Pattern.UNIX_LINES);
-		Pattern p2 = Pattern.compile(".*\\s*Duration: (\\d\\d):(\\d\\d):(\\d\\d)\\.(\\d).*",
+		Pattern p2 = Pattern.compile(".*\\s*Duration: (\\d\\d):(\\d\\d):(\\d\\d).(\\d\\d),",
 				Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.UNIX_LINES);
 		Pattern p3 = Pattern.compile(".*\\s*Stream #\\S+: ((?:Audio)|(?:Video)|(?:Data)): (.*)\\s*.*",
 				Pattern.CASE_INSENSITIVE | Pattern.MULTILINE | Pattern.UNIX_LINES);
@@ -161,8 +161,8 @@ public class Encoder {
 			long hours = Integer.parseInt(m.group(1));
 			long minutes = Integer.parseInt(m.group(2));
 			long seconds = Integer.parseInt(m.group(3));
-			long dec = Integer.parseInt(m.group(4));
-			long duration = dec * 100L + seconds * 1000L + minutes * 60L * 1000L + hours * 60L * 60L * 1000L;
+			long centiSeconds = Integer.parseInt(m.group(4));
+			long duration = centiSeconds * 10L + (seconds + minutes * 60L + hours * 60L * 60L) * 1000L;
 			info.setDuration(duration);
 		}
 


### PR DESCRIPTION
Hello :smile: 

While using Tarsos for a couple of songs, I've ran into this message: "Source and target should have similar duration..." :
When I analysed both files, I realised their duration was almost the same, varying only in centiseconds! :confused: 

Since running ffmpeg manually in the cmd line, yeld the same result, I tried review the code that parses and calculates the duration of a song, allowing me to uncover 2 probable defects:
- First, ffmpeg returns something like this: "Duration: 00:04:23.78, bitrate: 352 kb/s", yet in line 142, this regex wasn't capturing the centiseconds properly, since it was only expecting 1 digit instead of 2 (probably expecting deciseconds instead of centiseconds?)
- Secondly, in line 165, the centiseconds were being multiplied by 100 (deciseconds to milliseconds) instead of 10 (centiseconds to milliseconds).

I have tested this in Windows 7 x64 and it solves my problem regarding duration missmatch between source and target. 

I hope I was able to explain myself clearly :smiley:  For any additional information or clarification, just ask.
